### PR TITLE
add missing pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,12 @@ Also you could merge other DDSketch:
  */
 
 mod error;
-mod index_mapping;
+pub mod index_mapping;
 mod input;
 mod output;
 mod serde;
 mod sketch;
-mod store;
+pub mod store;
 
 pub use self::error::Error;
 pub use self::input::DefaultInput;


### PR DESCRIPTION
Thanks for the crate! I'm currently evaluating different quantile algorithms for percentile aggregations in [tantivy](https://github.com/quickwit-oss/tantivy/) and so far this crate looks pretty good.

It still got some rough edges.
Without the exporting the types, the DDSketch struct can't be stored. Having to define `DDSketch<CubicallyInterpolatedMapping, CollapsingLowestDenseStore>,` is a odd API, so maybe it's better to hide these details and wrap them in a new type that gets exported.

```rust
use sketches_rust::index_mapping::CubicallyInterpolatedMapping;
use sketches_rust::store::CollapsingLowestDenseStore;
struct DDSketch2 {
    sketch: sketches_rust::DDSketch<CubicallyInterpolatedMapping, CollapsingLowestDenseStore>,
    error: f64,
    max_buckets: usize,
}

impl DDSketch {
    fn new(error: f64, max_buckets: usize) -> Self {
        Self {
            sketch: sketches_rust::DDSketch::collapsing_lowest_dense(error, max_buckets).unwrap(),
            error,
            max_buckets,
        }
    }
}

```