### PR TITLE
fix mutability, fix visibility, clippy

### DIFF
--- a/src/index_mapping/cubically_interpolated.rs
+++ b/src/index_mapping/cubically_interpolated.rs
@@ -21,10 +21,10 @@ impl CubicallyInterpolatedMapping {
         let long_bits = value.to_bits() as i64;
         let s: f64 = serde::get_significand_plus_one(long_bits) - 1.0;
         let e: f64 = serde::get_exponent(long_bits) as f64;
-        return ((CubicallyInterpolatedMapping::A * s + CubicallyInterpolatedMapping::B) * s
+        ((CubicallyInterpolatedMapping::A * s + CubicallyInterpolatedMapping::B) * s
             + CubicallyInterpolatedMapping::C)
             * s
-            + e;
+            + e
     }
 
     fn log_inverse(&self, index: f64) -> f64 {
@@ -48,7 +48,7 @@ impl CubicallyInterpolatedMapping {
         let significand_plus_one = -(CubicallyInterpolatedMapping::B + p + d0 / p)
             / (3.0 * CubicallyInterpolatedMapping::A)
             + 1.0;
-        return serde::build_double(exponent, significand_plus_one);
+        serde::build_double(exponent, significand_plus_one)
     }
 }
 
@@ -67,15 +67,15 @@ impl IndexMapping for CubicallyInterpolatedMapping {
 
     fn index(&self, value: f64) -> i32 {
         let index: f64 = self.log(value) * self.multiplier + self.index_offset;
-        return if index >= 0.0 {
+        if index >= 0.0 {
             index as i32
         } else {
             (index - 1.0) as i32
-        };
+        }
     }
 
     fn value(&self, index: i32) -> f64 {
-        return self.lower_bound(index) * (1.0 + self.relative_accuracy);
+        self.lower_bound(index) * (1.0 + self.relative_accuracy)
     }
 
     fn lower_bound(&self, index: i32) -> f64 {

--- a/src/index_mapping/logarithmic.rs
+++ b/src/index_mapping/logarithmic.rs
@@ -37,15 +37,15 @@ impl IndexMapping for LogarithmicMapping {
 
     fn index(&self, value: f64) -> i32 {
         let index: f64 = self.log(value) * self.multiplier + self.index_offset;
-        return if index >= 0.0 {
+        if index >= 0.0 {
             index as i32
         } else {
             (index - 1.0) as i32
-        };
+        }
     }
 
     fn value(&self, index: i32) -> f64 {
-        return self.lower_bound(index) * (1.0 + self.relative_accuracy);
+        self.lower_bound(index) * (1.0 + self.relative_accuracy)
     }
 
     fn lower_bound(&self, index: i32) -> f64 {

--- a/src/index_mapping/mod.rs
+++ b/src/index_mapping/mod.rs
@@ -40,14 +40,14 @@ pub enum IndexMappingLayout {
 impl IndexMappingLayout {
     pub fn of_flag(flag: &Flag) -> Result<IndexMappingLayout, Error> {
         let index = flag.get_marker() >> 2;
-        return match index {
+        match index {
             0 => Ok(IndexMappingLayout::LOG),
             1 => Ok(IndexMappingLayout::LogLinear),
             2 => Ok(IndexMappingLayout::LogQuadratic),
             3 => Ok(IndexMappingLayout::LogCubic),
             4 => Ok(IndexMappingLayout::LogQuartic),
             _ => Err(Error::InvalidArgument("Unknown Index Flag.")),
-        };
+        }
     }
 
     pub fn to_flag(self) -> Flag {
@@ -58,7 +58,7 @@ impl IndexMappingLayout {
 
 fn calculate_relative_accuracy(gamma: f64, correcting_factor: f64) -> f64 {
     let exact_log_gamma = gamma.powf(correcting_factor);
-    return (exact_log_gamma - 1.0) / (exact_log_gamma + 1.0);
+    (exact_log_gamma - 1.0) / (exact_log_gamma + 1.0)
 }
 
 fn calculate_gamma(relative_accuracy: f64, correcting_factor: f64) -> f64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,12 @@ mod store;
 
 pub use self::error::Error;
 pub use self::index_mapping::CubicallyInterpolatedMapping;
+pub use self::index_mapping::IndexMapping;
 pub use self::index_mapping::LogarithmicMapping;
 use self::input::DefaultInput;
 use self::output::DefaultOutput;
 pub use self::sketch::DDSketch;
 pub use self::store::CollapsingHighestDenseStore;
 pub use self::store::CollapsingLowestDenseStore;
+pub use self::store::Store;
 pub use self::store::UnboundedSizeDenseStore;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use Result;
+
 
 mod default;
 pub use default::DefaultOutput;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -54,7 +54,7 @@ pub fn decode_var_double(input: &mut impl Input) -> Result<f64, Error> {
         bits |= ((next as i64) & 127) << shift;
         shift -= 7;
     }
-    return Ok(var_bits_to_double(bits));
+    Ok(var_bits_to_double(bits))
 }
 
 pub fn i64_to_i32_exact(value: i64) -> Result<i32, Error> {
@@ -88,7 +88,7 @@ pub fn build_double(exponent: i64, significand_plus_one: f64) -> f64 {
 }
 
 fn zig_zag_decode(value: i64) -> i64 {
-    return ((value as u64) >> 1) as i64 ^ (-(value & 1));
+    ((value as u64) >> 1) as i64 ^ (-(value & 1))
 }
 
 fn var_bits_to_double(bits: i64) -> f64 {
@@ -99,7 +99,7 @@ pub fn ignore_exact_summary_statistic_flags(
     input: &mut impl Input,
     flag: Flag,
 ) -> Result<(), Error> {
-    return if flag == Flag::COUNT {
+    if flag == Flag::COUNT {
         decode_var_double(input)?;
         Ok(())
     } else if flag == Flag::SUM || flag == Flag::MIN || flag == Flag::MAX {
@@ -107,7 +107,7 @@ pub fn ignore_exact_summary_statistic_flags(
         Ok(())
     } else {
         Err(Error::InvalidArgument("Unknown Flag."))
-    };
+    }
 }
 
 pub fn encode_var_double(output: &mut impl Output, value: f64) -> Result<(), Error> {
@@ -119,7 +119,7 @@ pub fn encode_var_double(output: &mut impl Output, value: f64) -> Result<(), Err
             output.write_byte(next)?;
             return Ok(());
         }
-        output.write_byte((next | 0x80) as u8)?;
+        output.write_byte(next | 0x80)?;
     }
     output.write_byte((bits >> (8 * 7)) as u8)?;
     Ok(())
@@ -133,19 +133,19 @@ fn double_to_var_bits(value: f64) -> u64 {
 }
 
 pub fn unsigned_var_long_encoded_length(value: i64) -> i64 {
-    return UNSIGNED_VAR_LONG_LENGTHS[value.leading_zeros() as usize];
+    UNSIGNED_VAR_LONG_LENGTHS[value.leading_zeros() as usize]
 }
 
 pub fn signed_var_long_encoded_length(value: i64) -> i64 {
-    return UNSIGNED_VAR_LONG_LENGTHS[i64::leading_zeros(zig_zag_encode(value)) as usize];
+    UNSIGNED_VAR_LONG_LENGTHS[i64::leading_zeros(zig_zag_encode(value)) as usize]
 }
 
 pub fn var_double_encoded_length(value: f64) -> i64 {
-    return VAR_DOUBLE_LENGTHS[i64::trailing_zeros(double_to_var_bits(value) as i64) as usize];
+    VAR_DOUBLE_LENGTHS[i64::trailing_zeros(double_to_var_bits(value) as i64) as usize]
 }
 
 fn zig_zag_encode(value: i64) -> i64 {
-    return value >> (64 - 1) ^ (value << 1);
+    value >> (64 - 1) ^ (value << 1)
 }
 
 pub fn encode_unsigned_var_long(output: &mut impl Output, mut value: i64) -> Result<(), Error> {
@@ -153,7 +153,7 @@ pub fn encode_unsigned_var_long(output: &mut impl Output, mut value: i64) -> Res
     let mut i = 0;
     while i < length && i < 8 {
         output.write_byte((value | 0x80) as u8)?;
-        value = value >> 7;
+        value >>= 7;
         i += 1;
     }
     output.write_byte(value as u8)?;

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -94,7 +94,7 @@ impl<I: IndexMapping, S: Store> DDSketch<I, S> {
     }
 
     pub fn get_max(&mut self) -> Option<f64> {
-        return if !self.positive_value_store.is_empty() {
+        if !self.positive_value_store.is_empty() {
             Some(
                 self.index_mapping
                     .value(self.positive_value_store.get_max_index()),
@@ -109,11 +109,11 @@ impl<I: IndexMapping, S: Store> DDSketch<I, S> {
             )
         } else {
             None
-        };
+        }
     }
 
     pub fn get_min(&mut self) -> Option<f64> {
-        return if !self.negative_value_store.is_empty() {
+        if !self.negative_value_store.is_empty() {
             Some(
                 -self
                     .index_mapping
@@ -128,7 +128,7 @@ impl<I: IndexMapping, S: Store> DDSketch<I, S> {
             )
         } else {
             None
-        };
+        }
     }
 
     pub fn get_average(&mut self) -> Option<f64> {
@@ -136,11 +136,11 @@ impl<I: IndexMapping, S: Store> DDSketch<I, S> {
         if count <= 0.0 {
             return None;
         }
-        return Some(self.get_sum()? / count);
+        Some(self.get_sum()? / count)
     }
 
     pub fn get_value_at_quantile(self: &mut DDSketch<I, S>, quantile: f64) -> Option<f64> {
-        if quantile < 0.0 || quantile > 1.0 {
+        if !(0.0..=1.0).contains(&quantile) {
             return None;
         }
 
@@ -241,7 +241,7 @@ impl<I: IndexMapping, S: Store> DDSketch<I, S> {
         self.positive_value_store
             .merge_with(&mut other.positive_value_store);
         self.zero_count += other.zero_count;
-        return Ok(());
+        Ok(())
     }
 
     pub fn encode(&self) -> Result<Vec<u8>, Error> {

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -244,7 +244,7 @@ impl<I: IndexMapping, S: Store> DDSketch<I, S> {
         return Ok(());
     }
 
-    pub fn encode(&mut self) -> Result<Vec<u8>, Error> {
+    pub fn encode(&self) -> Result<Vec<u8>, Error> {
         let mut output = DefaultOutput::with_capacity(64);
         self.index_mapping.encode(&mut output)?;
 

--- a/src/store/collapsing_highest.rs
+++ b/src/store/collapsing_highest.rs
@@ -15,7 +15,7 @@ pub struct CollapsingHighestDenseStore {
 
 impl CollapsingHighestDenseStore {
     pub fn with_capacity(capacity: usize) -> Result<Self, Error> {
-        if capacity > 2147483647 || capacity < 1 {
+        if !(1..=2147483647).contains(&capacity) {
             return Err(Error::InvalidArgument(
                 "Too large capacity: should be between 1 and 2147483648.",
             ));

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -93,7 +93,7 @@ pub trait Store {
         input: &mut impl Input,
         mode: BinEncodingMode,
     ) -> Result<(), Error> {
-        return match mode {
+        match mode {
             BinEncodingMode::IndexDeltasAndCounts => {
                 let num_bins = serde::decode_unsigned_var_long(input)?;
                 let mut index: i64 = 0;
@@ -136,7 +136,7 @@ pub trait Store {
                 }
                 Ok(())
             }
-        };
+        }
     }
     fn get_descending_stream(&mut self) -> Vec<(i32, f64)>;
     fn get_ascending_stream(&mut self) -> Vec<(i32, f64)>;
@@ -176,12 +176,12 @@ impl<'a> StoreIter<'a> {
 impl<'a> Iterator for StoreIter<'a> {
     type Item = (i32, f64);
     fn next(&mut self) -> Option<Self::Item> {
-        return if self.desc {
+        if self.desc {
             if self.max_index < self.min_index {
                 return None;
             }
 
-            let index = self.max_index as i32;
+            let index = self.max_index;
             self.max_index -= 1;
 
             while self.max_index >= self.min_index {
@@ -199,7 +199,7 @@ impl<'a> Iterator for StoreIter<'a> {
                 return None;
             }
 
-            let index = self.min_index as i32;
+            let index = self.min_index;
             self.min_index += 1;
 
             while self.min_index <= self.max_index {
@@ -212,7 +212,7 @@ impl<'a> Iterator for StoreIter<'a> {
 
             let count = self.counts[(index - self.offset) as usize];
             Some((index, count))
-        };
+        }
     }
 }
 
@@ -235,7 +235,7 @@ impl BinEncodingMode {
 
     pub fn to_flag(self, store_flag_type: FlagType) -> Flag {
         let sub_flag = self as u8;
-        return Flag::with_type(store_flag_type, sub_flag);
+        Flag::with_type(store_flag_type, sub_flag)
     }
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -27,7 +27,7 @@ pub trait Store {
     fn get_min_index(&self) -> i32;
     fn get_max_index(&self) -> i32;
     fn get_count(&self, i: i32) -> f64;
-    fn encode(&mut self, output: &mut impl Output, store_flag_type: FlagType) -> Result<(), Error> {
+    fn encode(&self, output: &mut impl Output, store_flag_type: FlagType) -> Result<(), Error> {
         if self.is_empty() {
             return Ok(());
         }


### PR DESCRIPTION
- fix mutability, fix visibility
- fix clippy issues

The mutability on encode is not required. 
2 exports were missing `IndexMapping` and `Store`.

Executed:
`cargo clippy --fix`

There are still some clippy issues, that could not be fixed automatically